### PR TITLE
Fix mkmakefile creating too many chapters

### DIFF
--- a/buch/papers/common/Makefile.inc
+++ b/buch/papers/common/Makefile.inc
@@ -61,9 +61,6 @@ $(workdir)/buch12-blx.bbl:	$(workdir)/buch12-blx.aux
 $(workdir)/buch13-blx.bbl:	$(workdir)/buch13-blx.aux
 	cd $(workdir); bibtex buch13-blx
 
-$(workdir)/buch14-blx.bbl:	$(workdir)/buch14-blx.aux
-	cd $(workdir); bibtex buch14-blx
-
 BLXFILES = $(workdir)/buch.bbl \
 	$(workdir)/buch1-blx.bbl \
 	$(workdir)/buch2-blx.bbl \
@@ -78,7 +75,6 @@ BLXFILES = $(workdir)/buch.bbl \
 	$(workdir)/buch11-blx.bbl \
 	$(workdir)/buch12-blx.bbl \
 	$(workdir)/buch13-blx.bbl \
-	$(workdir)/buch14-blx.bbl \
 
 $(workdir)/SeminarHarmonischeAnalysis1-blx.bbl:	$(workdir)/SeminarHarmonischeAnalysis1-blx.aux
 	cd $(workdir); bibtex SeminarHarmonischeAnalysis1-blx

--- a/buch/papers/scripts/mkmakefile
+++ b/buch/papers/scripts/mkmakefile
@@ -45,10 +45,8 @@ awk 'BEGIN {
 	counter++
 }
 END {
-	printf("buch%d-blx.bbl:\tbuch%d-blx.aux\n", counter, counter)
-	printf("\tbibtex buch%d-blx\n\n", counter)
 	printf("BLXFILES = buch.bbl \\\n")
-	for (i = 1; i <= counter; i++) {
+	for (i = 1; i < counter; i++) {
 		printf("\tbuch%d-blx.bbl \\\n", i)
 	}
 	#printf("\tbuch%d-blx.bbl\n", i)


### PR DESCRIPTION
I was having this error during the build process of the book:
```
Database file #13: ../papers/wavelets/references.bib
Database file #14: ../papers/brown/references.bib
Database file #15: ../papers/opt/references.bib
Biblatex version: 3.19
make: *** Keine Regel vorhanden, um das Ziel „build/buch14-blx.aux“, benötigt von „build/buch14-blx.bbl“, zu erstellen.  Schluss.
```
The file `buch/papers/common/paperlist'` contains 13 lines, so the awk command in `buch/papers/scripts/mkmakefile` counts from 1 to 13, but ends with 14, as there is a "counter++" just before it goes to the `END`.
The patch in the attachment solved this issue for me.
Hopefully it does not introduce any problems for other systems that might have a slightly different behaving `awk`.